### PR TITLE
Improve squashing alogrithm to account for stair stepping topography/bathymetry.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 List of changes to query software for each release.
 
+## Version 1.1.1, 2018-12-14
+
+* Improve the squashing algorithm to account for stair stepping in the
+  Etree. The Etree doesn't include octants in which the topography or
+  bathymetry is above their base but below their centroids.
+
 ## Version 1.1.0, 2018-09-21
 
 * Added binary packages for Linux and Darwin (Mac OS X) and

--- a/docs/query.md
+++ b/docs/query.md
@@ -114,20 +114,19 @@ wavelength of shear waves at a given period.
 #### Squashing topography/bathymetry
 
 There are two settings that permit the velocity structure to be
-adjusted so that the top surface is aligned with sea level. The
-default query behavior does NOT use squashing. Squashing, by default,
-is limited to elevations above -2 km. That is, the geometry of the
-model above an elevation of -2 km (2 km below sea level) is moved
-up/down so that that ground surface is at sea level. Below an
-elevation of -2 km, the geometry of the seismic velocity model is
-retained.
+adjusted so that the top of the solid earth surface is aligned with
+sea level. That is, the topographic surface is pushed down to sea
+level and the ocean bathymetry is pulled up to sea level. Points below
+the squashing limit (as given by an elevation value) will not be
+translated up or down; this maintains the relative geometry of deeper
+structures, such as sedimentary basins.
 
-The elevation of the ground surface used in squashing topography is
-found by performaing a `MAXRES` query for the elevation of topography at
-the location of the velocity model query. Thus, the resolution of the
-elevation used to squash topography is coarser for points deep in the
-model (provided the location lies above the depth extent of
-squashing).
+The elevation of the solid earth surface used in squashing is found by
+performing a `MAXRES` query for the elevation of
+topography/bathymetry at the location of the velocity model
+query. Thus, the resolution of the elevation used to squash is coarser
+for points deep in the model (provided the location lies above the
+depth extent of squashing).
 
 ## Applications
 

--- a/libsrc/cencalvm/query/VMQuery.h
+++ b/libsrc/cencalvm/query/VMQuery.h
@@ -266,13 +266,15 @@ private :
    * @param lon Longitude of location for query in degrees
    * @param lat Latitude of location for query in degrees
    * @param elev Elevation of location wrt MSL in meters
+   * @param allowAdjustment Allow adjusting elevation to insure queries are below topography.
    *
    * @returns Elevation of ground surface at location.
    */
   double _queryElev(etree_addr_t* pAddr,
 		    const double lon,
 		    const double lat,
-		    const double elev);
+		    const double elev,
+		    const bool allowAdjustment=false);
 
   /** Set payload to NODATA values.
    *


### PR DESCRIPTION
Improve squashing algorithm to account for topography/bathymetry cutting
through the bottom half of octants. These octants are not included in
the Etree, so queries just below the topography/bathymetry surface would
not return data. The remedy is to detect these cases and return the
values in the octant directly below the desired one.

Ultimately, converting the rasterized model from uniform values within a
cell to interpolated values would avert this issue.